### PR TITLE
Resolved Issue #10: Debugged removal of infeasible irreversible reactions

### DIFF
--- a/ecmtool/helpers.py
+++ b/ecmtool/helpers.py
@@ -376,7 +376,7 @@ def print_ecms_direct(R, metabolite_ids):
         mp_print("")
 
 
-def normalize_columns(R, verbose=False):
+def normalize_columns_slower(R, verbose=False):  # This was the original function, but seems slower and further equivalent to new function below
     result = np.zeros(R.shape)
     number_rays = R.shape[1]
     for i in range(result.shape[1]):
@@ -387,11 +387,22 @@ def normalize_columns(R, verbose=False):
         largest_number = np.max(np.abs(R[:,i]))
         if largest_number > 1e100:  # If numbers are very large, converting to float might give issues, therefore we first divide by another int
             part_normalized_column = np.array(R[:, i] / largest_number, dtype='float')
-            result[:, i] = part_normalized_column / np.linalg.norm(part_normalized_column)
+            result[:, i] = part_normalized_column / np.linalg.norm(part_normalized_column, ord=1)
         else:
             norm_column = np.linalg.norm(np.array(R[:, i], dtype='float'), ord=1)
             if norm_column != 0:
                 result[:, i] = np.array(R[:, i], dtype='float') / norm_column
+    return result
+
+
+def normalize_columns(R, verbose=False):
+    result = R
+    largest_number = max(np.max(R), -np.min(R))
+    if largest_number > 1e100:
+        result = result / largest_number # If numbers are very large, converting to float might give issues, therefore we first divide by another int
+    norms = np.linalg.norm(result, axis=0, ord=1)
+    norms[np.where(norms==0)[0]] = 1
+    result = np.array(np.divide(result, norms), dtype='float')
     return result
 
 

--- a/ecmtool/network.py
+++ b/ecmtool/network.py
@@ -402,13 +402,11 @@ class Network:
         original_internal = len(self.metabolites) - len(self.external_metabolite_indices())
         original_reversible = len(self.reversible_reaction_indices())
         no_fixed_point = True
-        debug_counter = 0
 
         while no_fixed_point:
             before_met_count, before_reac_count = self.N.shape
             self.compress_inner(verbose=verbose, SCEI=SCEI, cycle_removal=cycle_removal,
-                                remove_infeasible=remove_infeasible, debug_counter=debug_counter)
-            debug_counter = debug_counter + 1
+                                remove_infeasible=remove_infeasible)
             after_met_count, after_reac_count = self.N.shape
             if (after_met_count - before_met_count == 0) & (after_reac_count - before_reac_count == 0):
                 no_fixed_point = False
@@ -429,7 +427,7 @@ class Network:
             mp_print('Compressed size: %.2f%%' % (((float(reaction_count) * metabolite_count) / (
                     original_reaction_count * original_metabolite_count)) * 100))
 
-    def compress_inner(self, verbose=False, SCEI=True, cycle_removal=False, remove_infeasible=True, debug_counter=0):
+    def compress_inner(self, verbose=False, SCEI=True, cycle_removal=False, remove_infeasible=True):
         """
 
         :param verbose:

--- a/ecmtool/network.py
+++ b/ecmtool/network.py
@@ -730,7 +730,7 @@ class Network:
             if np.min(N_int.shape) == 0:
                 break
             else:
-                nullspace_int = null_space(normalize_columns(N_int))  # TODO: See if you can make normalize_columns faster
+                nullspace_int = null_space(normalize_columns(N_int))
             reacs_notin_nullspace = np.where(np.max(np.abs(nullspace_int), axis=1) < 1e-8)[0]
             if len(reacs_notin_nullspace):
                 removable_reactions.extend(reacs_notin_nullspace)

--- a/ecmtool/network.py
+++ b/ecmtool/network.py
@@ -773,7 +773,6 @@ class Network:
 
                 if len(removable_reactions):
                     self.drop_reactions(removable_reactions)
-                    pass
 
         n_reactions_after = len(self.reactions)
         if verbose:


### PR DESCRIPTION
The issue arose when the nullspace was calculated for a matrix of very large numbers. Therefore, I now changed:
- standard column-wise normalisation using fractions before converting the matrix to floats
- sped up normalisation by trying to use numpy rather than looping over columns