### PR TITLE
Install `lrslib` with apt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,6 @@
 FROM python:3.10-slim
 
-RUN apt update && apt install -y git openssh-client build-essential bash openjdk-17-jre libopenmpi-dev libgmp-dev wget
-
-RUN wget http://cgm.cs.mcgill.ca/~avis/C/lrslib/archive/lrslib-071a.tar.gz && tar -xzf lrslib-071a.tar.gz
-RUN cd lrslib-071a && make && make mplrs && make install && \
-    mv `pwd`/mplrs /usr/local/bin/mplrs && mv `pwd`/redund /usr/local/bin/redund && \
-    mv `pwd`/*.so /usr/local/lib
-RUN ldconfig
+RUN apt update && apt install -y git openssh-client build-essential bash openjdk-17-jre libopenmpi-dev libgmp-dev wget lrslib
 
 COPY ecmtool /ecmtool/ecmtool/
 COPY models /ecmtool/models/
@@ -21,7 +15,7 @@ RUN python3 setup.py install
 
 # Make sure we don't have to run as root
 RUN useradd -ms /bin/bash user
-RUN chown -R user:user /ecmtool /lrslib*
+RUN chown -R user:user /ecmtool
 USER user
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
The link to the `lrslib` source code is broken, and the compilation procedure appears to have changed between 0.71 and 0.72.

This pull request installs `lrslib` with apt instead, which includes `mplrs`, the parallel wrapper for `redund`.
https://manpages.debian.org/unstable/lrslib/redund.1.en.html